### PR TITLE
Move pcov extension check to runtime

### DIFF
--- a/bin/pcov
+++ b/bin/pcov
@@ -71,6 +71,10 @@ if ($config["path"]) {
 	}
 }
 
+if (!extension_loaded('pcov')) {
+    usage("The pcov extension does not seem to be available");
+}
+
 if (class_exists(PHPUnit_Runner_Version::class) &&
     (\version_compare(PHPUnit_Runner_Version::id(), "5", ">="))) {
     $config["version"] = 5;

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,10 @@
 {
     "name": "pcov/clobber",
     "require": {
-	"ext-pcov": "^1.0",
-        "nikic/php-parser": "^4.2"
+	"nikic/php-parser": "^4.2"
+    },
+    "suggest": {
+        "ext-pcov": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e3afe406957fb7e00ec91ea3863e875",
+    "content-hash": "beca2b727c3db1419533813184fa1250",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v4.2.0",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "594bcae1fc0bccd3993d2f0d61a018e26ac2865a"
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/594bcae1fc0bccd3993d2f0d61a018e26ac2865a",
-                "reference": "594bcae1fc0bccd3993d2f0d61a018e26ac2865a",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,8 @@
                 "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5 || ^7.0"
+                "ircmaxell/php-yacc": "0.0.5",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -33,7 +34,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -55,7 +56,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-01-12T16:31:37+00:00"
+            "time": "2019-11-08T13:50:10+00:00"
         }
     ],
     "packages-dev": [],
@@ -64,8 +65,6 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {
-        "ext-pcov": "^1.0"
-    },
+    "platform": [],
     "platform-dev": []
 }


### PR DESCRIPTION
I would love to include pcov-clobber as one of our dev dependencies, but the reality is that many of our developers will not have the `pcov` extension installed. Those people will either make use of alternate code coverage tooling (phpdbg, xdbebug), or are not generating code coverage reports.

In its current form, it is not possible to `composer install` for other unrelated dev dependencies without now installing a PHP extension.

I would argue that pcov should only be a `suggests` and  not a `requires`, and that the check for pcov should be a runtime check instead.